### PR TITLE
PR: 페이지네이션 구현 성공

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,6 +12,7 @@ module.exports = {
 	settings: { react: { version: '18.2' } },
 	plugins: ['react-refresh', 'react', 'unused-imports', 'prettier'],
 	rules: {
+		'react/prop-types': 'off',
 		'react-refresh/only-export-components': [
 			'warn',
 			{ allowConstantExport: true },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-redux": "^9.0.4",
+				"react-router-dom": "^6.21.0",
 				"redux": "^5.0.0",
 				"styled-components": "^6.1.1"
 			},
@@ -992,6 +993,14 @@
 				"react-redux": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@remix-run/router": {
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.14.0.tgz",
+			"integrity": "sha512-WOHih+ClN7N8oHk9N4JUiMxQJmRVaOxcg8w7F/oHUXzJt920ekASLI/7cYX8XkntDWRhLZtsk6LbGrkgOAvi5A==",
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@types/babel__core": {
@@ -4067,6 +4076,36 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-router": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.21.0.tgz",
+			"integrity": "sha512-hGZ0HXbwz3zw52pLZV3j3+ec+m/PQ9cTpBvqjFQmy2XVUWGn5MD+31oXHb6dVTxYzmAeaiUBYjkoNz66n3RGCg==",
+			"dependencies": {
+				"@remix-run/router": "1.14.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8"
+			}
+		},
+		"node_modules/react-router-dom": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.21.0.tgz",
+			"integrity": "sha512-1dUdVj3cwc1npzJaf23gulB562ESNvxf7E4x8upNJycqyUm5BRRZ6dd3LrlzhtLaMrwOCO8R0zoiYxdaJx4LlQ==",
+			"dependencies": {
+				"@remix-run/router": "1.14.0",
+				"react-router": "6.21.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8",
+				"react-dom": ">=16.8"
 			}
 		},
 		"node_modules/redux": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-redux": "^9.0.4",
+		"react-router-dom": "^6.21.0",
 		"redux": "^5.0.0",
 		"styled-components": "^6.1.1"
 	},

--- a/src/MainPage.jsx
+++ b/src/MainPage.jsx
@@ -1,10 +1,24 @@
+import { useSearchParams } from 'react-router-dom'
 import styled from 'styled-components'
 import { Header, IssueBox, PaginationBtn } from './components/@index'
 import useIssue from './hooks/UseIssue'
 import flexAlign from './styles/themes/FlexAlign'
 
 function MainPage() {
-	const issues = useIssue()
+	const queryKeyDefault = { page: 1, perPage: 10, sort: 'created' }
+	const [queryParam, setQueryParam] = useSearchParams(queryKeyDefault)
+
+	const onChangeParam = (key, value) => {
+		queryParam.set(key, value)
+		setQueryParam(queryParam)
+	}
+
+	const issues = useIssue(
+		queryParam.get('page'),
+		queryParam.get('perPage'),
+		queryParam.get('sort')
+	)
+
 	return (
 		<S.Div_AlignWrap>
 			<S.Div_HeaderWrap>
@@ -28,8 +42,15 @@ function MainPage() {
 
 			<S.Div_BtnWrap>
 				{new Array(10).fill(0).map((_, idx) => {
-					console.log(idx)
-					return <PaginationBtn key={idx} number={idx + 1} />
+					return (
+						<PaginationBtn
+							key={idx}
+							number={idx + 1}
+							onClick={() => {
+								onChangeParam('page', idx + 1)
+							}}
+						/>
+					)
 				})}
 			</S.Div_BtnWrap>
 		</S.Div_AlignWrap>

--- a/src/MainPage.jsx
+++ b/src/MainPage.jsx
@@ -1,17 +1,36 @@
 import styled from 'styled-components'
 import { Header, IssueBox, PaginationBtn } from './components/@index'
+import useIssue from './hooks/UseIssue'
 import flexAlign from './styles/themes/FlexAlign'
+
 function MainPage() {
+	const issues = useIssue()
 	return (
 		<S.Div_AlignWrap>
 			<S.Div_HeaderWrap>
 				<Header />
 			</S.Div_HeaderWrap>
-			<S.Div_IuuseWrap>
-				<IssueBox />
-			</S.Div_IuuseWrap>
+
+			<S.Div_IssueWrap>
+				{issues.map((issue) => {
+					return (
+						<IssueBox
+							key={issue.id}
+							id={issue.id}
+							title={issue.title}
+							numComments={issue.comments}
+							author={issue.user.id}
+							createAt={issue.created_at}
+						/>
+					)
+				})}
+			</S.Div_IssueWrap>
+
 			<S.Div_BtnWrap>
-				<PaginationBtn />
+				{new Array(10).fill(0).map((_, idx) => {
+					console.log(idx)
+					return <PaginationBtn key={idx} number={idx + 1} />
+				})}
 			</S.Div_BtnWrap>
 		</S.Div_AlignWrap>
 	)
@@ -22,22 +41,25 @@ export default MainPage
 const Div_AlignWrap = styled.div`
 	${flexAlign.flexCenter}
 	${flexAlign.directionColumn}
+	padding-bottom: 1rem;
 `
 const Div_HeaderWrap = styled.div`
 	width: 100%;
 `
 
-const Div_IuuseWrap = styled.div`
+const Div_IssueWrap = styled.div`
 	${flexAlign.justifyBetween}
-	width: 90%;
+	width: 60%;
 	flex-wrap: wrap;
 `
 const Div_BtnWrap = styled.div`
 	width: 100%;
+	${flexAlign.flexCenter}
+	gap: 1%;
 `
 const S = {
 	Div_AlignWrap,
 	Div_HeaderWrap,
-	Div_IuuseWrap,
+	Div_IssueWrap,
 	Div_BtnWrap,
 }

--- a/src/components/IssueBox.jsx
+++ b/src/components/IssueBox.jsx
@@ -1,26 +1,14 @@
 import styled from 'styled-components'
-import useIssue from '../hooks/UseIssue'
 import { color, flexAlign, fontSize, fontWeight } from '../styles/themes/@index'
-const IssueBox = () => {
-	const issues = useIssue()
+const IssueBox = ({ id, title, numComments, author, createAt }) => {
 	return (
-		<>
-			{issues.map((issue, idx) => {
-				return (
-					<S.Div_Wrapper key={idx}>
-						<S.Div_IssueId>ID:#{issue.id}</S.Div_IssueId>
-						<S.H1_Title>{issue.title}</S.H1_Title>
-						<S.Div_CommentsNumber>
-							comments:{`${issue.comments}`}
-						</S.Div_CommentsNumber>
-						<S.Div_Writter>작성자 : {issue.user.login}</S.Div_Writter>
-						<S.Div_CreatedTime>
-							created_at :{issue.created_at}
-						</S.Div_CreatedTime>
-					</S.Div_Wrapper>
-				)
-			})}
-		</>
+		<S.Div_Wrapper>
+			<S.Div_IssueId>ID: #{id}</S.Div_IssueId>
+			<S.H1_Title>{title}</S.H1_Title>
+			<S.Div_CommentsNumber>comments: {numComments}</S.Div_CommentsNumber>
+			<S.Div_Author>작성자 : {author}</S.Div_Author>
+			<S.Div_CreatedTime>created_at :{createAt}</S.Div_CreatedTime>
+		</S.Div_Wrapper>
 	)
 }
 export default IssueBox
@@ -60,7 +48,7 @@ const Div_CreatedTime = styled.div`
 	font-weight: ${fontWeight.regular};
 `
 
-const Div_Writter = styled.div`
+const Div_Author = styled.div`
 	position: absolute;
 	right: 0;
 	top: 0;
@@ -74,5 +62,5 @@ const S = {
 	H1_Title,
 	Div_CommentsNumber,
 	Div_CreatedTime,
-	Div_Writter,
+	Div_Author,
 }

--- a/src/components/PaginationBtn.jsx
+++ b/src/components/PaginationBtn.jsx
@@ -1,121 +1,24 @@
 import styled from 'styled-components'
-import { flexAlign, fontSize, fontWeight } from '../styles/themes/@index'
-import { useDispatch } from 'react-redux'
-import { reload } from '../slice/IssueListSlice'
-import getIssuesList from '../apis/Issues'
-import { useRef } from 'react'
-const PaginationBtn = () => {
-	const dispatch = useDispatch()
-	const curPage = useRef(1)
-	const curPerPage = useRef(10)
-	const curSort = useRef('created')
-
-	const fetchIssueBox = (page, perPage, sort) => {
-		const fetchNRegisterIssueList = async () => {
-			let issueList = []
-			try {
-				issueList = await getIssuesList(page, perPage, sort)
-			} catch {
-				issueList = []
-			}
-			dispatch(reload(issueList))
-		}
-		fetchNRegisterIssueList()
-	}
-
-	const onClickNumBtn = (page) => {
-		curPage.current = page
-		fetchIssueBox(curPage.current, curPerPage.current, curSort.current)
-	}
-	const onClickNextBtn = () => {
-		curPage.current += 1
-		fetchIssueBox(curPage.current, curPerPage.current, curSort.current)
-	}
-	const onClickPrevBtn = () => {
-		if (curPage.current === 1) return
-		curPage.current -= 1
-		fetchIssueBox(curPage.current, curPerPage.current, curSort.current)
-	}
-	const onClickStartPointBtn = () => {
-		curPage.current = 1
-		fetchIssueBox(curPage.current, curPerPage.current, curSort.current)
-	}
-	const onClickEndPointBtn = () => {
-		curPage.current = 10
-		fetchIssueBox(curPage.current, curPerPage.current, curSort.current)
-	}
-	const onClickCreatedBtn = () => {
-		curSort.current = 'created'
-		fetchIssueBox(curPage.current, curPerPage.current, curSort.current)
-	}
-	const onClickUpdatedBtn = () => {
-		curSort.current = 'updated'
-		fetchIssueBox(curPage.current, curPerPage.current, curSort.current)
-	}
-	const onClickCommentsBtn = () => {
-		curSort.current = 'comments'
-		fetchIssueBox(curPage.current, curPerPage.current, curSort.current)
-	}
-	const onClick10ListBtn = () => {
-		curPerPage.current = 10
-		fetchIssueBox(curPage.current, curPerPage.current, curSort.current)
-	}
-	const onClick20ListBtn = () => {
-		curPerPage.current = 20
-		fetchIssueBox(curPage.current, curPerPage.current, curSort.current)
-	}
-	const onClick50ListBtn = () => {
-		curPerPage.current = 50
-		fetchIssueBox(curPage.current, curPerPage.current, curSort.current)
-	}
-
-	return (
-		<S.Div_BtnWrap>
-			<S.But_Button onClick={onClick10ListBtn}>10개씩보기</S.But_Button>
-			<S.But_Button onClick={onClick20ListBtn}>20개씩보기</S.But_Button>
-			<S.But_Button onClick={onClick50ListBtn}>50개씩보기</S.But_Button>
-			<S.But_Button onClick={onClickStartPointBtn}>{`${'<<'}`}</S.But_Button>
-			<S.But_Button onClick={onClickPrevBtn}>{`${'<'}`}</S.But_Button>
-			{Array(10)
-				.fill(0)
-				.map((_, idx) => {
-					return (
-						<S.But_Button
-							key={idx}
-							onClick={() => {
-								onClickNumBtn(idx + 1)
-							}}
-						>
-							{idx + 1}
-						</S.But_Button>
-					)
-				})}
-			<S.But_Button onClick={onClickNextBtn}>{`${'>'}`}</S.But_Button>
-			<S.But_Button onClick={onClickEndPointBtn}>{`${'>>'}`}</S.But_Button>
-			<S.But_Button onClick={onClickCreatedBtn}>생성순</S.But_Button>
-			<S.But_Button onClick={onClickUpdatedBtn}>업데이트순</S.But_Button>
-			<S.But_Button onClick={onClickCommentsBtn}>코멘트순</S.But_Button>
-		</S.Div_BtnWrap>
-	)
+import { color, fontSize, fontWeight } from '../styles/themes/@index'
+const PaginationBtn = ({ number }) => {
+	return <S.But_Button onClick={() => {}}>{number}</S.But_Button>
 }
 export default PaginationBtn
-const Div_BtnWrap = styled.div`
-	${flexAlign.flexCenter}
-`
 
 const But_Button = styled.button`
-	margin: 1rem;
+	width: 3rem;
+	height: fit-content;
 	padding: 1rem;
-	font-size: ${fontSize.large};
+	text-align: center;
+	font-size: ${fontSize.tiny};
 	font-weight: ${fontWeight.bold};
-	border: 0;
-	background-color: transparent;
+	border: 1px solid ${color.grayScale[0]};
+	background-color: ${color.grayScale[80]};
 	&:hover {
 		cursor: pointer;
+		background-color: ${color.grayScale[60]};
 	}
 `
-
 const S = {
-	Div_BtnWrap,
 	But_Button,
 }

--- a/src/components/PaginationBtn.jsx
+++ b/src/components/PaginationBtn.jsx
@@ -1,7 +1,8 @@
 import styled from 'styled-components'
 import { color, fontSize, fontWeight } from '../styles/themes/@index'
-const PaginationBtn = ({ number }) => {
-	return <S.But_Button onClick={() => {}}>{number}</S.But_Button>
+
+const PaginationBtn = ({ number, ...rest }) => {
+	return <S.But_Button {...rest}>{number}</S.But_Button>
 }
 export default PaginationBtn
 

--- a/src/hooks/UseIssue.js
+++ b/src/hooks/UseIssue.js
@@ -59,7 +59,7 @@ const useIssue = (page, perPage, sort) => {
 			}
 			dispatch(reload(issueList))
 		}
-		fetchNRegisterIssueList()
+		fetchNRegisterIssueList(page, perPage, sort)
 	}, [dispatch, page, perPage, sort])
 
 	return issues

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,10 +6,8 @@ import Store from './store/Store.js'
 import GlobalStyles from './styles/GlobalStyles.jsx'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-	
-		<Provider store={Store}>
-			<GlobalStyles />
-			<MainPage />
-		</Provider>
-	
+	<Provider store={Store}>
+		<GlobalStyles />
+		<MainPage />
+	</Provider>
 )

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,25 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { Provider } from 'react-redux'
+import { RouterProvider, createBrowserRouter } from 'react-router-dom'
 import MainPage from './MainPage.jsx'
 import Store from './store/Store.js'
 import GlobalStyles from './styles/GlobalStyles.jsx'
 
+const router = createBrowserRouter([
+	{
+		path: '',
+		element: <MainPage />,
+	},
+	{
+		path: '*',
+		element: <div>🖕</div>,
+	},
+])
+
 ReactDOM.createRoot(document.getElementById('root')).render(
 	<Provider store={Store}>
 		<GlobalStyles />
-		<MainPage />
+		<RouterProvider router={router} />
 	</Provider>
 )


### PR DESCRIPTION
- [refactor: MainPage 구조 변경](https://github.com/2023-frontend1/Frontend-RestAPI/commit/906364c6535827b765db34d25ba7d5f7f4b80109)
  - @snkchan 컴포넌트 구조 변경했습니다. 죄송합니다.. 확인부탁드립니다.
  
- [depend: react-router-dom 의존성](https://github.com/2023-frontend1/Frontend-RestAPI/commit/350623278694917f4dc2c8a1a7cd1dd61450f544)
  - react-router-dom 라이브러리 다시 추가했습니다. 
  - 이유는 query-parameter 값을 이용해서, 데이터 패칭 & 상태등록 & reRendering 하기 위함 입니다.
  - 추가로 페이지 번호 등을 기역했다가, 뒤로가기 구현이 가능합니다.

- [feat: query-parameter 로 페이지 이동](https://github.com/2023-frontend1/Frontend-RestAPI/commit/3987cf3cd4035bef119e838f312a0406b2f4e312)
  - useSearchParams() 사용해서 url 주소에 page,perPage,sort 값을 저장합니다.
  - 동영상 참고 바랍니다. (특히 주소창)
  
  
  

https://github.com/2023-frontend1/Frontend-RestAPI/assets/50646145/63bc9ad5-1809-4acf-bfd1-01c98e636a82

